### PR TITLE
Add CI and Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,9 @@ jobs:
           sudo apt-get install --yes shellcheck stow zsh
 
       - name: Check install script
-        run: shellcheck install.sh
+        run: |
+          shellcheck install.sh
+          dash -n install.sh
 
       - name: Check Zsh syntax
         run: find zsh -type f -exec zsh -n {} +

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,68 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: Shell and Stow
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install validation tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes shellcheck stow zsh
+
+      - name: Check install script
+        run: shellcheck install.sh
+
+      - name: Check Zsh syntax
+        run: find zsh -type f -exec zsh -n {} +
+
+      - name: Check Brewfile syntax
+        run: ruby -c Brewfile
+
+      - name: Check Dependabot configuration syntax
+        run: ruby -e 'require "yaml"; YAML.load_file(".github/dependabot.yml")'
+
+      - name: Check Stow layout
+        run: |
+          stow_target="${RUNNER_TEMP}/stow-home"
+          mkdir -p "$stow_target"
+          stow --target="$stow_target" zsh config
+          test -L "$stow_target/.zprofile"
+          test -L "$stow_target/.zshrc"
+          test -L "$stow_target/.gitconfig"
+
+  brewfile:
+    name: Brewfile
+    runs-on: macos-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Validate Brewfile
+        env:
+          HOMEBREW_NO_AUTO_UPDATE: "1"
+        run: brew bundle list --all --file Brewfile > /dev/null

--- a/install.sh
+++ b/install.sh
@@ -24,14 +24,12 @@ if ! command -v brew > /dev/null; then
   esac
 fi
 
-if [ ! -d ~/dotfiles ]; then
-  cd ~
+if [ ! -d "$HOME/dotfiles" ]; then
+  cd "$HOME"
   git clone https://github.com/K0201N/dotfiles.git
 fi
 
-pushd ~/dotfiles
-brew bundle --file=~/dotfiles/Brewfile
-stow -v -t ~ zsh config
-popd
+brew bundle --file="$HOME/dotfiles/Brewfile"
+stow -v -d "$HOME/dotfiles" -t "$HOME" zsh config
 
 echo "Done!"


### PR DESCRIPTION
## Summary

- add GitHub Actions checks for ShellCheck, Zsh syntax, Brewfile validity, and Stow layout
- add weekly grouped Dependabot updates for GitHub Actions
- make `install.sh` compatible with its `/bin/sh` shebang by removing `pushd` and `popd`

## Why

The repository had no automated validation for shell configuration or the Brewfile. In addition, `install.sh` used non-POSIX directory stack commands even though it is executed with `sh`, which could fail on shells such as `dash`.

## Impact

Pushes to `main` and pull requests now validate the dotfiles on Ubuntu and macOS. GitHub Actions references will be checked weekly and grouped into one Dependabot pull request.

## Validation

- ShellCheck v0.11.0
- `dash -n install.sh`
- Zsh syntax checks
- Brewfile Ruby syntax and `brew bundle list`
- isolated Stow installation
- workflow and Dependabot YAML parsing
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改善**
  - 初回セットアップ時の dotfiles 配置処理を改善し、既存環境で不要な再取得や移動が発生しないようにしました。
  - パッケージのインストールと設定ファイルの配置先を明確化し、セットアップの安定性を向上しました。

- **品質向上**
  - コードや設定ファイルの自動チェックを追加し、変更による問題を早期に検出できるようにしました。
  - GitHub Actions の依存関係を定期的に確認・更新する仕組みを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->